### PR TITLE
Make list item display correctly.

### DIFF
--- a/_posts/2012-04-19-contributing.markdown
+++ b/_posts/2012-04-19-contributing.markdown
@@ -12,13 +12,14 @@ The guides site uses [jekyll](https://github.com/mojombo/jekyll) to power the si
 2. Do a `git clone` of your fork.
 3. Create a file named `YYYY-MM-DD-guide_name.markdown` inside the `_posts` directory of your fork.
 4. In this file, you'll need to add some YAML front matter at the top of the file so it looks like the following example, taken from this guide that you are currently viewing:
-{% highlight yaml %}
----
-layout: default
-title: Contributing a Guide
-permalink: contributing
----
-{% endhighlight %}
+
+    <pre>
+    ---
+    layout: default
+    title: Contributing a Guide
+    permalink: contributing
+    ---</pre>
+
 5. Commit this new guide to your git repo.
 6. After you commit, push that to your fork.
 7. You can now open a pull request explaining your guide. That's it!


### PR DESCRIPTION
Follow up of #219.

After #219, Step 5, 6, 7 becomes 1, 2, 3.

This is a workaround to make the numbered list in order, but lost the syntax highlight of yaml. 

### Before

![screenshot 2014-12-12 23 09 22](https://cloud.githubusercontent.com/assets/1000669/5413712/0970ddbe-8254-11e4-9c4f-6bca734ea423.png)

### After

![screenshot 2014-12-12 23 09 02](https://cloud.githubusercontent.com/assets/1000669/5413714/0c783fc0-8254-11e4-9fd5-eb73e968eec6.png)
