### PR TITLE
Replace 'floor' method explanation with explanation of integer division

### DIFF
--- a/_posts/2014-05-10-ruby-atm.markdown
+++ b/_posts/2014-05-10-ruby-atm.markdown
@@ -91,6 +91,14 @@ my_age = 28
 half_my_age = my_age / 2
 {% endhighlight %}
 
+In ruby, when you do division with two whole numbers (integers), the result is rounded down to the nearest whole number.
+
+{% highlight ruby %}
+new_number = 25/10
+# new_number contains 2, because 25/10 = 2.5, and ruby will round that down to 2.
+{% endhighlight %}
+
+
 ### Tests for step 2:
 
 {% highlight ruby %}
@@ -226,23 +234,6 @@ Imagine your ATM now holds $5 and $10. People want as few notes as possible.
 
 * `withdraw(25)` should return `[10, 10, 5]`
 * `withdraw(11)` should return `false`, because $11 cannot be made up of $5 and $10 notes
-
-**Tips for getting tests green:**
-
-In ruby, when you do division with two whole numbers (integers), the result is rounded down to the nearest whole number.
-
-{% highlight ruby %}
-new_number = 25/10
-# new_number contains 2, because 25/10 = 2.5, and ruby will round that down to 2.
-{% endhighlight %}
-
-The percent sign (%) is called the modulo operator and you can use it to get the remainder
-
-{% highlight ruby %}
-new_number = 25%10
-# new_number contains 5, because 10 goes into 25 two times and there is 5 remainder
-{% endhighlight %}
-
 
 ### Tests for step 5
 

--- a/_posts/2014-05-10-ruby-atm.markdown
+++ b/_posts/2014-05-10-ruby-atm.markdown
@@ -229,13 +229,18 @@ Imagine your ATM now holds $5 and $10. People want as few notes as possible.
 
 **Tips for getting tests green:**
 
-The `floor` method rounds a number down to the nearest whole integer. For example:
+In ruby, when you do division with two whole numbers (integers), the result is rounded down to the nearest whole number.
 
 {% highlight ruby %}
-my_number = 3.87.floor # my_number contains 3
+new_number = 25/10
+# new_number contains 2, because 25/10 = 2.5, and ruby will round that down to 2.
+{% endhighlight %}
 
-new_number = (25/10).floor
-# new_number contains 2, because 25/10 = 2.5, and floor will round that down to 2.
+The percent sign (%) is called the modulo operator and you can use it to get the remainder
+
+{% highlight ruby %}
+new_number = 25%10
+# new_number contains 5, because 10 goes into 25 two times and there is 5 remainder
 {% endhighlight %}
 
 


### PR DESCRIPTION
The explanation of the floor method is not necessary because ruby automatically floors integer division. 