### PR TITLE
Fix code icons

### DIFF
--- a/js/guides.js
+++ b/js/guides.js
@@ -27,9 +27,9 @@ function detectOs() {
 }
 
 function addIcons() {
-  $("code.sh, code.bat").closest('.highlight').before('<i class="icon-small-prompt"></i>');
-  $("code.erb, code.html, code.ruby, code.css").closest('.highlight').before('<i class="icon-small-text-editor"></i>');
-  $("code.browser").closest('.highlight').before('<i class="icon-small-browser"></i>');
+  $("code.language-sh, code.language-bat").closest('.highlight').before('<i class="icon-small-prompt"></i>');
+  $("code.language-erb, code.language-html, code.language-ruby, code.language-css").closest('.highlight').before('<i class="icon-small-text-editor"></i>');
+  $("code.language-browser").closest('.highlight').before('<i class="icon-small-browser"></i>');
 }
 
 function initializeOsSwitchers() {


### PR DESCRIPTION
Hi :blush: 
I fixed class names in the JS file to add icons that show which to use text editor or terminal or browser.

## Before
![image](https://cloud.githubusercontent.com/assets/4459676/7449171/ed8385ac-f26a-11e4-8283-e278810db9d8.png)

![image](https://cloud.githubusercontent.com/assets/4459676/7449173/f66baafa-f26a-11e4-9ec1-8743ffa7758b.png)

## After
![image](https://cloud.githubusercontent.com/assets/4459676/7449163/b9ea9eba-f26a-11e4-9242-58aee114dea2.png)

![image](https://cloud.githubusercontent.com/assets/4459676/7449167/cf6f9cae-f26a-11e4-87b6-ae18a9e6cd96.png)
