### PR TITLE
Sunset Nitrous.io

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -37,7 +37,7 @@ permalink: app
 
 ### Important
 
-It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands. In case you're using a cloud service (e.g. nitrous), you need to run the Linux commands even if you are on a Windows computer.
+It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands.
 
 ## *1.*Creating the application
 
@@ -48,7 +48,6 @@ First, let's open a terminal:
 * Mac OS X: Open Spotlight, type *Terminal* and click the *Terminal* application.
 * Windows: Click Start and look for *Command Prompt*, then click *Command Prompt with Ruby on Rails*.
 * Linux (Ubuntu/Fedora): Search for *Terminal* on the dash and click *Terminal*.
-* Cloud service (e.g. nitrous): Log in to your account, start your box and switch to its IDE (see [installation guide](/install#using-a-cloud-service) for details). The terminal is usually at the bottom of your browser window.
 
 Next, type these commands in the terminal:
 
@@ -130,7 +129,7 @@ rails server
   </div>
 </div>
 
-Open <http://localhost:3000> in your browser. If you are using a cloud service (e.g. nitrous), use its preview functionality instead (see [installation guide](/install#using-a-cloud-service) for details).
+Open <http://localhost:3000> in your browser.
 
 You should see "Welcome aboard" page, which means that the generation of your new app worked correctly.
 
@@ -184,7 +183,7 @@ rails server
   </div>
 </div>
 
-Open <http://localhost:3000/ideas> in your browser. Cloud service (e.g. nitrous) users need to append '/ideas' to their preview url instead (see [installation guide](/install#using-a-cloud-service)).
+Open <http://localhost:3000/ideas> in your browser.
 
 Click around and test what you got by running these few command-line commands.
 
@@ -371,7 +370,7 @@ Now refresh your browser to see what changed.
 
 ## *5.*Finetune the routes
 
-Open <http://localhost:3000> (or your preview url, if you are using a cloud service). It still shows the "Welcome aboard" page. Let's make it redirect to the ideas page.
+Open <http://localhost:3000>. It still shows the "Welcome aboard" page. Let's make it redirect to the ideas page.
 
 Open `config/routes.rb` and after the first line add
 
@@ -401,7 +400,7 @@ It also adds a new simple route to your routes.rb.
 get "pages/info"
 {% endhighlight %}
 
-Now you can open the file `app/views/pages/info.html.erb` and add information about you in HTML. To see your new info page, take your browser to <http://localhost:3000/pages/info> or, if you are a cloud service user, append '/pages/info' to your preview url.
+Now you can open the file `app/views/pages/info.html.erb` and add information about you in HTML. To see your new info page, take your browser to <http://localhost:3000/pages/info>.
 
 ## *6+.*What next?
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -15,7 +15,6 @@ Follow the instructions for your operating system. If you run into any problems,
 * [Setup for Windows](#setup-for-windows)
 * [Setup for Linux](#setup-for-linux)
 * [Alternative Installment for all OS](#virtual-machine)
-* [Using a Cloud Service - No Installation Required](#using-a-cloud-service)
 
 <hr />
 
@@ -271,38 +270,3 @@ Now you should have a working Ruby on Rails programming setup. Congrats!
 Instead of installing all tools on your machine, you can also set up a development environment in a Virtual Machine. Please find all the details [here]({% post_url 2014-03-24-alternative-dev-environment %}).
 
 <hr />
-
-## Using a Cloud Service
-
-Instead of installing Ruby on Rails and an editor on your computer, you can use a webservice for development. All you need is a browser and an internet connection. This guide explains how to get started with [nitrous.io](https://nitrous.io). If you're using a different service, they may use a different wording - e.g. 'workspace' instead of 'box', but the process is usually pretty similar.
-
-### *1.* Update your browser
-
-If you use Internet Explorer, we recommend installing [Firefox](mozilla.org/firefox) or [Google Chrome](google.com/chrome).
-
-Open [whatbrowser.org](http://whatbrowser.org) and update your browser if you don't have the latest version.
-
-### *2.* Create a free account
-Go to [https://nitrous.io](https://nitrous.io/) and signup for free.
-
-### *3.* Setup a development box / workspace for ruby on rails
-* Login to your nitrous account
-* Go to the dashboard by using the green 'Open dashboard' button
-* Create a nitrous box: pick Ruby/Rails from the templates - everything else can stay as is, but you can change the name of your box if you want to
-* It takes a moment until your box is ready
-
-### *4.* Find and restart your development box
-* If you've just created your box, you can probably skip these steps - they're good to know if you login to nitrous again later
-* You can always find your nitrous boxes by going to the dashboard or choosing 'Boxes' from the top menu
-* Pick your box from the list of boxes
-* If you haven't used a box in a while, it might have been shutdown due to inactivity. If you are informed that your box is not running, restart it using the respective button
-* When your box is up and running, choose 'IDE' in order to start coding
-
-### *5.* Coding with your development box
-* On the left hand side, you find a file browser where you can navigate your directories and file
-* In the middle, you find the editor where you can modify your files
-* At the bottom, you find the terminal where you can run commands
-* Everything you need is here in you browser window - you do not need to start an editor or terminal anywhere else
-* If your following a guide or tutorial, use the commands for Linux even if you are on a Windows computer - your operating system does not matter, since all commands are run on your development box, which is a Linux machine
-* If a guide or tutorial asks you to point your browser to something like http://localhost:3000, go to the 'Preview' menu and pick 'Port 3000'
-* If, for example, you're asked to open http://localhost:3000/posts, please append '/posts' manually to the URL that has been opened

--- a/_posts/2014-10-05-diary-app.markdown
+++ b/_posts/2014-10-05-diary-app.markdown
@@ -44,7 +44,7 @@ __COACH__: Assist with the installation; make sure the text editor is set up pro
 
 ### Important
 
-It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands. In case you're using a cloud service (e.g. nitrous), you need to run the Linux commands even if you are on a Windows computer.
+It is important that you select the instructions specific to your operating system - the commands you need to run on a Windows computer are slightly different to Mac or Linux. If you're having trouble check the Operating System switcher at the bottom of the commands.
 
 ## Pure HTML
 
@@ -119,8 +119,6 @@ __COACH__: Explain how the Web works and talk a bit about HTML elements and attr
 [Here](https://github.com/krzysztofbialek/Rails-Girls-Warsaw-App)'s a link to repo with styled basic app you can use.
 
 ## Moving to Rails
-
-__COACH__: If your students are on Windows, consider using Nitrous.IO as the basis for the following parts.
 
 ### New Rails application
 


### PR DESCRIPTION
> We recently announced that we will be sunsetting the original Nitrous product in favor of our new Nitrous Pro offering.

> Your old Nitrous account will be accessible at https://lite.nitrous.io until we sunset the old product on July 1st, 2015. If you have files that you would like to move to Nitrous Pro, you can read about migration options here:

:city_sunset::city_sunset::city_sunset: http://blog.nitrous.io/2015/04/23/nitrous-pro-faq.html

Alternatives: [Koding], [Cloud9], [Codebox]

/cc @igaiga 

[Koding]: https://koding.com/
[Cloud9]: https://c9.io/
[Codebox]: https://www.codebox.io/