### PR TITLE
add installation of node to the windows install to avoid ExecJS::Runtime Error

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -216,6 +216,21 @@ If you use Internet Explorer, we recommend installing [Firefox](mozilla.org/fire
 
 Open [whatbrowser.org](http://whatbrowser.org) and update your browser if you don't have the latest version.
 
+### *4.* Install node
+
+This is not strictly necessary, but it avoids a problem with and ExecJS::RuntimeError that might
+occur later  ([see stackoverflow](https://stackoverflow.com/questions/12520456/execjsruntimeerror-on-windows-trying-to-follow-rubytutorial)).
+
+* Go to [https://nodejs.org/](https://nodejs.org/) and install node
+
+Check your version of node
+
+{% highlight sh %}
+node --version
+{% endhighlight %}
+
+Make sure it is higher than `0.12`. 
+
 <hr />
 
 ## Setup for Linux


### PR DESCRIPTION
At Railsgirls munich we ran into problams with  ExecJS::Runtime Error in the ideas app
on many windows machines.  frantic research led to many hacky fixes.  
Installing node on the install day seems like the easiest solution.