### PR TITLE
Change descriptions for Nitrous PRO.

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -276,7 +276,7 @@ Instead of installing all tools on your machine, you can also set up a developme
 
 Instead of installing Ruby on Rails and an editor on your computer, you can use a webservice for development. All you need is a browser and an internet connection. This guide explains how to get started with [nitrous.io](https://nitrous.io). If you're using a different service, they may use a different wording - e.g. 'workspace' instead of 'box', but the process is usually pretty similar.
 
-**Organizer:** Nitrous is paid service but we can use freely in community using for now. Before we use, organizer should send mail to Nitrous (pro [at] nitrous.io) with follow contents for creating accounts.
+**Organizer:** Nitrous it a paid service but free for community usage purpose. Please contact Nitrous <pro [at] nitrous.io> to request for community account with follow list.
 
 - Email address of the people you need workspaces for (= email list of members)
 - How long they would need to use Nitrous

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -276,14 +276,22 @@ Instead of installing all tools on your machine, you can also set up a developme
 
 Instead of installing Ruby on Rails and an editor on your computer, you can use a webservice for development. All you need is a browser and an internet connection. This guide explains how to get started with [nitrous.io](https://nitrous.io). If you're using a different service, they may use a different wording - e.g. 'workspace' instead of 'box', but the process is usually pretty similar.
 
+**Organizer:** Nitrous is paid service but we can use freely in community using for now. Before we use, organizer should send mail to Nitrous (pro [at] nitrous.io) with follow contents for creating accounts.
+
+- Email address of the people you need workspaces for (= email list of members)
+- How long they would need to use Nitrous
+- Starting from date/time
+- How long (days, weeks etc.) you need access
+
 ### *1.* Update your browser
 
 If you use Internet Explorer, we recommend installing [Firefox](mozilla.org/firefox) or [Google Chrome](google.com/chrome).
 
 Open [whatbrowser.org](http://whatbrowser.org) and update your browser if you don't have the latest version.
 
-### *2.* Create a free account
-Go to [https://nitrous.io](https://nitrous.io/) and signup for free.
+### *2.* Create an account
+
+Go to [https://nitrous.io](https://nitrous.io/) and signup.
 
 ### *3.* Setup a development box / workspace for ruby on rails
 * Login to your nitrous account

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -276,7 +276,7 @@ Instead of installing all tools on your machine, you can also set up a developme
 
 Instead of installing Ruby on Rails and an editor on your computer, you can use a webservice for development. All you need is a browser and an internet connection. This guide explains how to get started with [nitrous.io](https://nitrous.io). If you're using a different service, they may use a different wording - e.g. 'workspace' instead of 'box', but the process is usually pretty similar.
 
-**Organizer:** Nitrous it a paid service but free for community usage purpose. Please contact Nitrous <pro [at] nitrous.io> to request for community account with follow list.
+**Organizer:** Nitrous is a paid service, but free for community usage purpose. Please contact Nitrous <pro [at] nitrous.io> to request a community account with the following list/information.
 
 - Email address of the people you need workspaces for (= email list of members)
 - How long they would need to use Nitrous


### PR DESCRIPTION
Nitrous will close free plan on 30th June, 2015.
We can use Nitrous freely after July, but we'll need a contact with email to Nitrous before using.

This PR is related with https://github.com/railsgirls/railsgirls.github.com/pull/241 .

I'm not good at English, so I hope these sentences collect with your comments or commits.
