### PR TITLE
Use newest stable ruby (2.2.3)

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -63,7 +63,7 @@ source ~/.bash_profile
 You can find the newest version of Ruby with the command "rbenv install -l".
 
 {% highlight sh %}
-rbenv install 2.2.0
+rbenv install 2.2.3
 {% endhighlight %}
 
 If you got "OpenSSL::SSL::SSLError: ... : certificate verify failed" error, try it this way.
@@ -76,7 +76,7 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 #### *3a5.* Set default Ruby:
 
 {% highlight sh %}
-rbenv global 2.2.0
+rbenv global 2.2.3
 {% endhighlight %}
 
 #### *3a6.* Install rails:


### PR DESCRIPTION
There were several severe bug fixes and security fixes in the past releases of 2.2.x. It's highly recommended to use the newest one.
https://www.ruby-lang.org/en/news/2015/03/03/ruby-2-2-1-released/
https://www.ruby-lang.org/en/news/2015/04/13/ruby-2-2-2-released/
https://www.ruby-lang.org/en/news/2015/08/18/ruby-2-2-3-released/