### PR TITLE
Restyle all keyboard shortcuts inside posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ If you aren't editing the code blocks, you can safely ignore this. If you want p
 $ jekyll server --watch
 ```
 
+### Styling
+
+Wrap keyboard shortcuts with [kbd](https://www.w3.org/wiki/HTML/Elements/kbd) HTML tag
+
+```
+To shut down the server you can hit <kbd>Ctrl</kbd>+<kbd>C</kbd>
+```
+
 ### Having trouble?
 
 You might find some useful hints in this jekyll issue if it's not working as expected: [Issue 503](https://github.com/mojombo/jekyll/issues/503)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ $ jekyll server --watch
 
 ### Styling
 
-Wrap keyboard shortcuts with [kbd](https://www.w3.org/wiki/HTML/Elements/kbd) HTML tag
+Wrap keyboard shortcuts with [kbd](https://www.w3.org/wiki/HTML/Elements/kbd) HTML tag.
+
+To make posts consistent in style use `Ctrl+C` over `CTRL-c`/`ctrl+c`
 
 ```
 To shut down the server you can hit <kbd>Ctrl</kbd>+<kbd>C</kbd>

--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -151,7 +151,7 @@ $
 
 When the command prompt is not visible you cannot execute new commands. If you try running `cd` or another command it will not work. To return to the normal command prompt:
 
-Hit `CTRL-C` in the terminal to quit the server.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to quit the server.
 
 **Coach:** Explain what each command does. What was generated? What does the server do?
 
@@ -188,7 +188,7 @@ Open <http://localhost:3000/ideas> in your browser. Cloud service (e.g. nitrous)
 
 Click around and test what you got by running these few command-line commands.
 
-Hit `CTRL-C` to quit the server again when you've clicked around a little.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> to quit the server again when you've clicked around a little.
 
 
 ## *3.*Design
@@ -292,7 +292,7 @@ gem 'carrierwave'
 
 **Coach:** Explain what libraries are and why they are useful. Describe what open source software is.
 
-Hit `CTRL-C` in the terminal to quit the server.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to quit the server.
 
 In the terminal run:
 

--- a/_posts/2014-02-13-simple-app.markdown
+++ b/_posts/2014-02-13-simple-app.markdown
@@ -162,7 +162,7 @@ $
 
 When the command prompt is not visible you cannot execute new commands. If you try running `cd` or another command it will not work. To return to the normal command prompt:
 
-Hit `CTRL-C` in the terminal to quit the server.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to quit the server.
 
 **Coach:** Explain what each command does. What was generated? What does the server do? You can find more details about the special template on [GitHub](https://github.com/Ben-M/simple_scaffold).
 
@@ -206,7 +206,7 @@ ruby bin\rails server
 
 Open [http://localhost:3000/ideas](http://localhost:3000/ideas) in your browser. Click around and test what you got by running these few command-line commands.
 
-Hit `CTRL-C` to quit the server again when you've clicked around a little.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> to quit the server again when you've clicked around a little.
 
 
 ## *3.*Design
@@ -322,7 +322,7 @@ rails generate uploader Picture
 
 At this point you need to **restart the Rails server process** in the terminal.
 
-Hit `CTRL-C` in the terminal to quit the server. Once it has stopped, you can press the up arrow to get to the last command entered, then hit enter to start the server again.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to quit the server. Once it has stopped, you can press the up arrow to get to the last command entered, then hit enter to start the server again.
 
 This is needed for the app to load the added library.
 

--- a/_posts/2014-03-24-alternative-dev-environment.markdown
+++ b/_posts/2014-03-24-alternative-dev-environment.markdown
@@ -63,7 +63,7 @@ We are going to refer to this tab in your browser as a console, you'll have to t
 
 #### Pasting text
 
-On Linux and Windows you won't be able to paste any copied code with the ordinary ctrl-v combination. Please use shift-insert instead, it should work.
+On Linux and Windows you won't be able to paste any copied code with the ordinary <kbd>Ctrl</kbd>+<kbd>V</kbd> combination. Please use shift-insert instead, it should work.
 
 ### Login
 

--- a/_posts/2014-05-09-test-driven-development.markdown
+++ b/_posts/2014-05-09-test-driven-development.markdown
@@ -76,7 +76,7 @@ end
 **Run your tests**
 
 If you use *Sublime Text* on Linux, OSX Mavericks (or later) or Windows, you
-can run the tests by pressing `Ctrl-B`. Otherwise you can type the following into
+can run the tests by pressing <kbd>Ctrl</kbd>+<kbd>B</kbd>. Otherwise you can type the following into
 your terminal:
 
 {% highlight sh %}

--- a/_posts/2014-05-10-ruby-atm.markdown
+++ b/_posts/2014-05-10-ruby-atm.markdown
@@ -18,7 +18,7 @@ We'll start simple, but ramp the difficulty up pretty steeply toward the end!
 
 For each step, you will need to take the following actions:
 
-**1. Run the new tests:** Delete tests from the previous step, and paste in the pre-written tests for the current step. *(Tests for each step are show at the bottom of that step.)* Run the tests to see which ones fail. In sublime text, you can hit `Ctrl-B` to run the tests. Or, you can open a terminal, `cd` into your working directory, and run `ruby atm.rb`.
+**1. Run the new tests:** Delete tests from the previous step, and paste in the pre-written tests for the current step. *(Tests for each step are show at the bottom of that step.)* Run the tests to see which ones fail. In sublime text, you can hit <kbd>Ctrl</kbd>+<kbd>B</kbd> to run the tests. Or, you can open a terminal, `cd` into your working directory, and run `ruby atm.rb`.
 
 **2. Make the tests pass:** Edit your code to meet the functionality requirements of the current step. You'll know you've got it right when all your tests are green.
 

--- a/_posts/2014-05-10-sinatra.markdown
+++ b/_posts/2014-05-10-sinatra.markdown
@@ -97,7 +97,7 @@ get "/page-name" do
  end
 {% endhighlight %}
 
-If you need to you can hit `ctrl-c` in your command prompt to stop your app. (Just like for your Rails app!), however you don't need to stop and start to see your changes. 
+If you need to you can hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in your command prompt to stop your app. (Just like for your Rails app!), however you don't need to stop and start to see your changes. 
 
 If you get stuck, make sure your app.rb looks like [this one](http://tjmcewan.github.io/coffeecalc/snippets/install_sinatra.rb.txt).
 

--- a/_posts/2014-05-29-touristic-autism_basic-app.markdown
+++ b/_posts/2014-05-29-touristic-autism_basic-app.markdown
@@ -153,7 +153,7 @@ $
 
 When the command prompt is not visible you cannot execute new commands. If you try running `cd` or another command it will not work. To return to the normal command prompt:
 
-Hit `CTRL-C` in the terminal to quit the server.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to quit the server.
 
 **Coach:** Explain what each command does. 
 [What is a web application and a server - Slides by @]()

--- a/_posts/2014-05-29-touristic-autism_image-upload.markdown
+++ b/_posts/2014-05-29-touristic-autism_image-upload.markdown
@@ -34,7 +34,7 @@ rails generate uploader Picture
 
 At this point you need to **restart the Rails server process** in the terminal.
 
-Hit `CTRL-C` in the terminal to quit the server. Once it has stopped, you can press the up arrow to get to the last command entered, then hit enter to start the server again.
+Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to quit the server. Once it has stopped, you can press the up arrow to get to the last command entered, then hit enter to start the server again.
 
 This is needed for the app to load the added library.
 

--- a/_posts/2014-10-02-sinatra-app-tutorial.markdown
+++ b/_posts/2014-10-02-sinatra-app-tutorial.markdown
@@ -41,7 +41,7 @@ You can actually call your Ruby file whatever you'd like. `vote.rb` for instance
 Go to the directory where you put your app and run `ruby suffragist.rb`.
 Now you can visit <a href="localhost:4567" target="_blank">localhost:4567</a>. You should
 see a ‘Hello, voter!’ page, which means that the generation of your new
-app worked correctly. Hit <kbd>Ctrl</kbd>+<kbd>c</kbd> in the terminal to shut down the server. If <kbd>Ctrl</kbd>+<kbd>c</kbd> does not work for you it means you are probably Windows user and <kbd>Ctrl</kbd>+<kbd>z</kbd>/ <kbd>Ctrl</kbd>+<kbd>pause</kbd> / <kbd>Ctrl</kbd>+<kbd>break</kbd> will fix the issue)
+app worked correctly. Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to shut down the server. If <kbd>Ctrl</kbd>+<kbd>C</kbd> does not work for you it means you are probably Windows user and <kbd>Ctrl</kbd>+<kbd>Z</kbd>/ <kbd>Ctrl</kbd>+<kbd>Pause</kbd> / <kbd>Ctrl</kbd>+<kbd>Break</kbd> will fix the issue)
 
 __COACH__: Explain POST and GET methods, and how to communicate with the browser.
 
@@ -101,7 +101,7 @@ end
 {% endhighlight %}
 
 Run `ruby suffragist.rb`, check your
-results and shut down the server with <kbd>Ctrl</kbd>+<kbd>c</kbd>.
+results and shut down the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
 
 __COACH__: Talk a little about HTML and erb. Explain
 templates. Explain what global constants are.
@@ -224,7 +224,7 @@ Create a new file in the `views` directory, called `results.erb`.
 {% endhighlight %}
 
 Run `ruby suffragist.rb`, check
-your results and shut down the server with <kbd>Ctrl</kbd>+<kbd>c</kbd>.
+your results and shut down the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
 
 __COACH__: Explain HTML tables and how how the
 missing values from the hash default to zero.

--- a/_posts/2014-10-02-sinatra-app-tutorial.markdown
+++ b/_posts/2014-10-02-sinatra-app-tutorial.markdown
@@ -41,7 +41,7 @@ You can actually call your Ruby file whatever you'd like. `vote.rb` for instance
 Go to the directory where you put your app and run `ruby suffragist.rb`.
 Now you can visit <a href="localhost:4567" target="_blank">localhost:4567</a>. You should
 see a ‘Hello, voter!’ page, which means that the generation of your new
-app worked correctly. Hit `ctrl+c` in the terminal to shut down the server. If `ctrl+c` does not work for you it means you are probably Windows user and `ctrl+z`/ `ctrl+pause` / `ctrl+break` will fix the issue)
+app worked correctly. Hit <kbd>Ctrl</kbd>+<kbd>c</kbd> in the terminal to shut down the server. If <kbd>Ctrl</kbd>+<kbd>c</kbd> does not work for you it means you are probably Windows user and <kbd>Ctrl</kbd>+<kbd>z</kbd>/ <kbd>Ctrl</kbd>+<kbd>pause</kbd> / <kbd>Ctrl</kbd>+<kbd>break</kbd> will fix the issue)
 
 __COACH__: Explain POST and GET methods, and how to communicate with the browser.
 
@@ -101,7 +101,7 @@ end
 {% endhighlight %}
 
 Run `ruby suffragist.rb`, check your
-results and shut down the server with `ctrl+c`.
+results and shut down the server with <kbd>Ctrl</kbd>+<kbd>c</kbd>.
 
 __COACH__: Talk a little about HTML and erb. Explain
 templates. Explain what global constants are.
@@ -224,7 +224,7 @@ Create a new file in the `views` directory, called `results.erb`.
 {% endhighlight %}
 
 Run `ruby suffragist.rb`, check
-your results and shut down the server with `ctrl+c`.
+your results and shut down the server with <kbd>Ctrl</kbd>+<kbd>c</kbd>.
 
 __COACH__: Explain HTML tables and how how the
 missing values from the hash default to zero.

--- a/_posts/2015-08-16-sinatra-app-tutorial-in-bulgarian.markdown
+++ b/_posts/2015-08-16-sinatra-app-tutorial-in-bulgarian.markdown
@@ -41,7 +41,7 @@ You can actually call your Ruby file whatever you'd like. `vote.rb` for instance
 Go to the directory where you put your app and run `ruby suffragist.rb`.
 Now you can visit [localhost:4567](http://localhost:4567). You should
 see a ‘Hello, voter!’ page, which means that the generation of your new
-app worked correctly. Hit `ctrl-c` in the terminal to quit the server.
+app worked correctly. Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal to quit the server.
 
 __COACH__: Explain POST and GET methods, and how to communicate with the browser.
 
@@ -101,7 +101,7 @@ end
 {% endhighlight %}
 
 Run `ruby suffragist.rb`, check your
-results and quit the server with `ctrl-c`.
+results and quit the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
 
 __COACH__: Talk a little about HTML and erb. Explain
 templates. Explain what global constants are.
@@ -224,7 +224,7 @@ Create a new file in the `views` directory, called `results.erb`.
 {% endhighlight %}
 
 Run `ruby suffragist.rb`, check
-your results and quit the server with `ctrl-c`.
+your results and quit the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
 
 __COACH__: Explain HTML tables and how how the
 missing values from the hash default to zero.

--- a/css/style.css
+++ b/css/style.css
@@ -278,3 +278,21 @@ i.icon-small-browser {
     background:none;
   }
 }
+
+kbd {
+    padding: .1em .6em;
+    border: 1px solid #ccc;
+    font-size: 11px;
+    font-family: Arial,Helvetica,sans-serif;
+    background-color: #f7f7f7;
+    color: #333;
+    -moz-box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+    -webkit-box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+    box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+    border-radius: 3px;
+    display: inline-block;
+    margin: 0 .1em;
+    text-shadow: 0 1px 0 #fff;
+    line-height: 1.4;
+    white-space: nowrap;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -293,6 +293,6 @@ kbd {
     display: inline-block;
     margin: 0 .1em;
     text-shadow: 0 1px 0 #fff;
-    line-height: 1.4;
+    line-height: 1.5em;
     white-space: nowrap;
 }


### PR DESCRIPTION
We found in https://github.com/railsgirls/railsgirls.github.com/pull/255#issuecomment-141504437 that we can improve a bit keyboard shortcuts inside posts.

To make content consistent in style I introduced guideline for shortcuts in [README](https://github.com/railsgirls/railsgirls.github.com/pull/256/files#diff-04c6e90faac2675aa89e2176d2eec7d8R40)