### PR TITLE
Clarify the position of commenting variables.

### DIFF
--- a/_posts/2012-04-30-commenting.markdown
+++ b/_posts/2012-04-30-commenting.markdown
@@ -65,12 +65,7 @@ add
 <%= render 'comments/form' %>
 {% endhighlight %}
 
-In `app/controllers/ideas_controller.rb` add to show action after the row
-{% highlight ruby %}
-@idea = Idea.find(params[:id])
-{% endhighlight %}
-
-this
+In `app/controllers/ideas_controller.rb` add to the show action
 {% highlight ruby %}
 @comments = @idea.comments.all
 @comment = @idea.comments.build


### PR DESCRIPTION
In more recent versions of Rails, the scaffolding generator moves `@idea` to a
before_filter/action and so it's no longer there. Instead, we should just tell
people to put the commenting variables into the show action.