### PR TITLE
Use bundle exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you aren't editing the code blocks, you can safely ignore this. If you want p
 ### Run jekyll
 
 ```
-$ jekyll server --watch
+$ bundle exec jekyll server --watch
 ```
 
 ### Styling


### PR DESCRIPTION
I had trouble with the Kramdown dependency, which is fixed by bundle exec.
Not sure what you think about suggesting to use it in the instructions.

@lbain - not sure what area you wanted me to update, but I'm just making this PR so that we can see that I have access :)