### PR TITLE
Minor improvement 2016-03-30-install.markdown on Windows installation

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -183,7 +183,7 @@ Check your version of rubygems
 gem -v
 {% endhighlight %}
 
-Make sure it is higher than `2.2.3`. Re-run the command that was failing previously.
+Make sure it is equal or higher than `2.2.3`. Re-run the command that was failing previously.
 
 
 ### 'x64_mingw' is not a valid platform` Error


### PR DESCRIPTION
Clarification for Windows installation that 2.2.3 version of gem is good enough to go and you do not use a higher version.