### PR TITLE
curl not installed on Ubuntu by default

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -243,6 +243,7 @@ To install the Ruby on Rails development environment you just need to copy the l
 #### For Ubuntu:
 
 {% highlight sh %}
+sudo apt-get install curl
 bash < <(curl -sL https://raw.github.com/railsgirls/installation-scripts/master/rails-install-ubuntu.sh)
 {% endhighlight %}
 


### PR DESCRIPTION
This is some fix for the same problem
we already fixed in the same fashion over at https://github.com/railsgirls/installation-scripts/issues/36 .

(See the README of https://github.com/railsgirls/installation-scripts for the result.)