### PR TITLE
Change rails new command instruction

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -102,7 +102,7 @@ gem update rails --no-ri --no-rdoc
 Make sure that all works well by running the application generator command.
 
 {% highlight sh %}
-rails new railsgirls
+rails new myapp
 {% endhighlight %}
 
 ### *4.* Install a text editor to edit code files
@@ -143,9 +143,7 @@ gem update rails --no-ri --no-rdoc
 Make sure that all works well by running the application generator command.
 
 {% highlight sh %}
-rails new railsgirls
-cd railsgirls
-rails server
+rails new myapp
 {% endhighlight %}
 
 ## Possible errors
@@ -257,9 +255,7 @@ bash < <(curl -sL https://raw.github.com/railsgirls/installation-scripts/master/
 Make sure that all works well by running the application generator command.
 
 {% highlight sh %}
-rails new railsgirls
-cd railsgirls
-rails server
+rails new myapp
 {% endhighlight %}
 
 


### PR DESCRIPTION
At the Rails Girls Berlin beginners' workshop yesterday we had
problems with multiple students who had followed the installation
instructions either at home or at the installation party the
evening before.

We shouldn't instruct beginners to create a new Rails app named
`railsgirls` to test their installation because that app name is
also used in the app guide. It can result in people having two
apps somewhere on their machine with the same name, which causes
confusion.

This changes the name of the app created in the installation
guide. We could also consider not creating an application at all
and just running `rails -v`.