### PR TITLE
Fix div closing in touristic autism intro

### DIFF
--- a/_posts/2014-05-29-touristic-autism_intro.markdown
+++ b/_posts/2014-05-29-touristic-autism_intro.markdown
@@ -25,16 +25,14 @@ The basic guides that have been merged and adapted are the [Ruby on Rails Tutori
 ### [*0.*Installation](/install)
 
 **Make sure you have Rails and Git installed.** [**Follow the installation guide**](/install), the [**Installing Git section of Pro Git**](http://www.git-scm.com/book/en/Getting-Started-Installing-Git) to get set up. Then configure GitHub by typing the following in your terminal:
-<div class="os-specific">
-  <div class="nix">
+
 {% highlight sh %}
 $ git config --global user.name "Your Name"
 $ git config --global user.email your.email@example.com
 {% endhighlight %}
 
-    <div>
 <p>one-time setup steps for GitHub.</p>
-    </div>
+
 Sign up for a [free GitHub account](https://github.com/signup/free) if you don’t have one already.
 
 


### PR DESCRIPTION
By browsing through existing guides I realized that something on the [Tourstic Autim Intro](http://guides.railsgirls.com/touristic-autism_intro) was broken:

<img width="1100" alt="screen shot 2016-04-24 at 12 28 59" src="https://cloud.githubusercontent.com/assets/5362483/14766873/e589c0a2-0a18-11e6-8586-641a91f47d19.png">

As the `git config` setup should be working also for windows I removed the `div`-blocks and now also the text afterwards is highlighted again correctly.