### PR TITLE
Float icon again but make code scrollable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -226,17 +226,17 @@ i.icon-prompt{
 i.icon-browser {
   background-image: url("/images/icon-browser.png");
 }
-/* The code lines are quite long.
-   Mobilize a lot of horizontal space for small screens: */
-@media (max-width: 1200px) {
-  figure.highlight {
-    margin: 0pt 0pt 15pt 0pt;
-  }
+
+.highlight {
+  margin-left: 30px;
 }
-@media(min-width: 1200px) {
-  figure.highlight {
-    margin: 0pt 40pt 25pt 0pt;
-  }
+
+.highlight pre {
+  overflow-x: auto;
+}
+
+.highlight pre code {
+  white-space: pre;
 }
 
 i.icon-small-text-editor, i.icon-small-prompt, i.icon-small-browser {
@@ -247,6 +247,7 @@ i.icon-small-text-editor, i.icon-small-prompt, i.icon-small-browser {
   width: 50px;
   height: 20px;
   line-height: 20px;
+  float: left;
 }
 i.icon-small-text-editor {
   background-image: url("/images/icon-small-text-editor.png");


### PR DESCRIPTION
I was seeing lately the CSS changes done in #278.

I have a counter purpose which I think will also be more resilient, even on smaller screens. I think icon & code should stay together as the icon has a lot of meaning.

Now:

<img width="479" alt="screen shot 2016-04-26 at 20 58 43" src="https://cloud.githubusercontent.com/assets/5362483/14830641/eb3dc554-0bf1-11e6-97b4-790b8575da00.png">

My change:

<img width="482" alt="screen shot 2016-04-26 at 20 58 18" src="https://cloud.githubusercontent.com/assets/5362483/14830651/faf7f6d6-0bf1-11e6-95fd-9879bd4f58a3.png">

Please let me know what you think :)