### PR TITLE
Remove the need to install rbenv-gem-rehash

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -52,7 +52,7 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 
 {% highlight sh %}
 brew update
-brew install rbenv rbenv-gem-rehash ruby-build
+brew install rbenv ruby-build
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 echo 'export PATH="$HOME/.rbenv/shims:$PATH"' >> ~/.bash_profile
 source ~/.bash_profile


### PR DESCRIPTION
Per https://github.com/Homebrew/legacy-homebrew/pull/47375 and https://github.com/Homebrew/homebrew-core/commit/40885ca386c8a8e945b5d08207396fab5d3ef921, the functionality was added into core rbenv, rendering this add-on unnecessary, and also removed from the homebrew tree.