### PR TITLE
Use `gem install` instead of shorthand

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -82,7 +82,7 @@ rbenv global 2.2.5
 #### *3a6.* Install rails:
 
 {% highlight sh %}
-gem i rails --no-document
+gem install rails --no-document
 {% endhighlight %}
 
 ### *3b.* If your OS X version is 10.6, 10.7, or 10.8:


### PR DESCRIPTION
`gem install` is used everywhere else. This might remove some ambiguity. The shortcut might be less intention revealing.

Thought about removing `--no-document` but it does speed things up.