### PR TITLE
Use CDN to fix certificate error in railsgirls app

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -206,8 +206,8 @@ Open `app/views/layouts/application.html.erb` in your text editor and above the 
 add
 
 {% highlight erb %}
-<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap.css">
-<link rel="stylesheet" href="//railsgirls.com/assets/bootstrap-theme.css">
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.css">
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap-theme.css">
 {% endhighlight %}
 
 and replace
@@ -255,7 +255,7 @@ and before `</body>` add
     Rails Girls 2015
   </div>
 </footer>
-<script src="//railsgirls.com/assets/bootstrap.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.js"></script>
 {% endhighlight %}
 
 Now let's also change the styling of the ideas table. Open `app/assets/stylesheets/application.css` and at the bottom add


### PR DESCRIPTION
Addresses this issue:
https://github.com/railsgirls/railsgirls.github.com/issues/261

I think it would be preferable to update the certificate because the new URLs more complicated and repetitive. Since I cannot contribute to updating the certificate, this PR is for the meantime.

3.0.3 is the same version that was being used.