### PR TITLE
Remove surplus reference to stop server

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -188,9 +188,6 @@ Open <http://localhost:3000/ideas> in your browser. Cloud service (e.g. nitrous)
 
 Click around and test what you got by running these few command-line commands.
 
-Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> to quit the server again when you've clicked around a little.
-
-
 ## *3.*Design
 
 **Coach:** Talk about the relationship between HTML and Rails. What part of views is HTML and what is Embedded Ruby (ERB)? What is MVC and how does this relate to it? (Models and controllers are responsible for generating the HTML views.)


### PR DESCRIPTION
Removing surplus instruction to stop the server.

It doesn't need to be stopped for code changes in the Design section.
There is a later instruction to stop the server immediately before running the `bundle` command.

If this instruction remains then the the later Ctrl+C instructs the the user to stop an already stopped server in the next section.