### PR TITLE
Remove specific instruction for Rails 3

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -383,8 +383,6 @@ Test the change by opening the root path (that is, <http://localhost:3000/> or y
 
 **Coach:** Talk about routes, and include details on the order of routes and their relation to static files.
 
-**Rails 3 users:** You will need to delete the index.html from the `/public/` folder for this to work.
-
 ## Create static page in your app
 
 Lets add a static page to our app that will hold information about the author of this application — you!


### PR DESCRIPTION
I can't imagine a situation where Rails 3 would be installed at a future event, at this stage in in the guide,  and I haven't seen other instruction catering for Rails 3.