### PR TITLE
Use Ruby 2.3.1 and Fix stylesheet syntax for Rails 5

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -197,7 +197,7 @@ The app doesn't look very nice yet. Let's do something about that. We'll use the
 Open `app/views/layouts/application.html.erb` in your text editor and above the line
 
 {% highlight erb %}
-<%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %>
+<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 {% endhighlight %}
 
 add

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -63,7 +63,7 @@ source ~/.bash_profile
 You can find the newest version of Ruby with the command "rbenv install -l".
 
 {% highlight sh %}
-rbenv install 2.2.5
+rbenv install 2.3.1
 {% endhighlight %}
 
 If you got "OpenSSL::SSL::SSLError: ... : certificate verify failed" error, try it this way.
@@ -76,7 +76,7 @@ cp /usr/local/opt/curl-ca-bundle/share/ca-bundle.crt `ruby -ropenssl -e 'puts Op
 #### *3a5.* Set default Ruby:
 
 {% highlight sh %}
-rbenv global 2.2.5
+rbenv global 2.3.1
 {% endhighlight %}
 
 #### *3a6.* Install rails:


### PR DESCRIPTION
I changed to use ruby 2.3.1 on Mac OSX.
I confirmed that there were no problems in the recipe of step 1 and 2, with Ruby 2.3.1 and Rails 5.0.0.

If this pull request is merged, I'll make other pull request as follows.
- Use local variable to the comments form partial generated by Rails 5
    - like this… `render 'comments/form'` -> `render 'comments/form', comment: @comment`
- Fix other outdated codes