### PR TITLE
Update to Rails5 on install and app pages

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -168,21 +168,10 @@ rails generate scaffold idea name:string description:text picture:string
 
 The scaffold creates new files in your project directory, but to get it to work properly we need to run a couple of other commands to update our database and restart the server.
 
-<div class="os-specific">
-  <div class="nix">
 {% highlight sh %}
-bin/rake db:migrate
+rails db:migrate
 rails server
 {% endhighlight %}
-  </div>
-
-  <div class="win">
-{% highlight sh %}
-ruby bin/rake db:migrate
-rails server
-{% endhighlight %}
-  </div>
-</div>
 
 Open <http://localhost:3000/ideas> in your browser. Cloud service (e.g. nitrous) users need to append '/ideas' to their preview url instead (see [installation guide](/install#using-a-cloud-service)).
 
@@ -312,7 +301,7 @@ This is needed for the app to load the added library.
 Open `app/models/idea.rb` and under the line
 
 {% highlight ruby %}
-class Idea < ActiveRecord::Base
+class Idea < ApplicationRecord
 {% endhighlight %}
 
 add
@@ -338,13 +327,13 @@ Sometimes, you might get an *TypeError: can't cast ActionDispatch::Http::Uploade
 If this happens, in file `app/views/ideas/_form.html.erb` change the line
 
 {% highlight erb %}
-<%= form_for(@idea) do |f| %>
+<%= form_for(idea) do |f| %>
 {% endhighlight %}
 
 to
 
 {% highlight erb %}
-<%= form_for @idea, :html => {:multipart => true} do |f| %>
+<%= form_for(idea, html: {multipart: true}) do |f| %>
 {% endhighlight %}
 
 In your browser, add new idea with a picture. When you upload a picture it doesn't look nice because it only shows a path to the file, so let's fix that.
@@ -358,7 +347,7 @@ Open `app/views/ideas/show.html.erb` and change
 to
 
 {% highlight erb %}
-<%= image_tag(@idea.picture_url, :width => 600) if @idea.picture.present? %>
+<%= image_tag(@idea.picture_url, width: 600) if @idea.picture.present? %>
 {% endhighlight %}
 
 Now refresh your browser to see what changed.
@@ -373,7 +362,7 @@ Open <http://localhost:3000> (or your preview url, if you are using a cloud serv
 Open `config/routes.rb` and after the first line add
 
 {% highlight ruby %}
-root :to => redirect('/ideas')
+root to: redirect('/ideas')
 {% endhighlight %}
 
 Test the change by opening the root path (that is, <http://localhost:3000/> or your preview url) in your browser.

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -130,7 +130,7 @@ Download [RailsInstaller](https://s3.amazonaws.com/railsinstaller/Windows/railsi
 
 Open `Command Prompt with Ruby on Rails` and run the following commands to solve a problem in RailsInstaller3.2.0.
 
-**Coach:** There is a bug that occurs "No such file or directory" error when use the `rails` command in RailsInstaller3.2.0. This is occured by incorrect pathes problems in rails.bat and bundle.bat. We can fix the problem copying rake.bat to rails.bat and bundle.bat. ([github issue page](https://github.com/railsinstaller/railsinstaller-windows/issues/76))
+**Coach:** There is a bug that occurs "No such file or directory" error when using the `rails` command in RailsInstaller3.2.0. This is occured by problem with incorrect paths in `rails.bat` and `bundle.bat`. We can fix the problem copying `rake.bat` to `rails.bat` and `bundle.bat`. ([github issue page](https://github.com/railsinstaller/railsinstaller-windows/issues/76))
 
 {% highlight sh %}
 cd C:\RailsInstaller\Ruby2.2.0\bin
@@ -234,7 +234,7 @@ Make sure it is displaying version number.
 
 ### *5.* Check the environment
 
-Make sure that all works well by running the application generator command.
+Check that everything is working by running the application generator command.
 
 {% highlight sh %}
 rails new myapp
@@ -242,11 +242,11 @@ cd myapp
 rails server
 {% endhighlight %}
 
-Access to `http://localhost:3000` on browser, and you can see the 'Yay! You're on Rails!' page.
+Go to `http://localhost:3000` in your browser, and you should see the 'Yay! You're on Rails!' page.
 
 Now you should have a working Ruby on Rails programming setup. Congrats!
 
-**Coach:** We recommend to check using a scaffold command and registing data in generated page by coaches, because we would get `ExecJS::RuntimeError` sometimes.
+**Coach:** We recommend to verify by using the scaffold command and inputting data with the generated page with coaches to avoid ensure everything is working.
 
 <hr />
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -126,7 +126,17 @@ Now you should have a working Ruby on Rails programming setup. Congrats!
 
 ### *1.* Install Rails
 
-Download [RailsInstaller](https://s3.amazonaws.com/railsinstaller/Windows/railsinstaller-3.1.0.exe) and run it. Click through the installer using the default options.
+Download [RailsInstaller](https://s3.amazonaws.com/railsinstaller/Windows/railsinstaller-3.2.0.exe) and run it. Click through the installer using the default options.
+
+Open `Command Prompt with Ruby on Rails` and run the following commands to solve a problem in RailsInstaller3.2.0.
+
+**Coach:** There is a bug that occurs "No such file or directory" error when use the `rails` command in RailsInstaller3.2.0. This is occured by incorrect pathes problems in rails.bat and bundle.bat. We can fix the problem copying rake.bat to rails.bat and bundle.bat. ([github issue page](https://github.com/railsinstaller/railsinstaller-windows/issues/76))
+
+{% highlight sh %}
+cd C:\RailsInstaller\Ruby2.2.0\bin
+copy rake.bat rails.bat
+copy rake.bat bundle.bat
+{% endhighlight %}
 
 Open `Command Prompt with Ruby on Rails` and run the following command:
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -150,12 +150,6 @@ If the Rails version is less than 5, update it using a following command:
 gem update rails --no-document
 {% endhighlight %}
 
-Make sure that all works well by running the application generator command.
-
-{% highlight sh %}
-rails new myapp
-{% endhighlight %}
-
 ## Possible errors
 
 ### Gem::RemoteFetcher error
@@ -216,8 +210,6 @@ For the workshop we recommend the text editor Atom.
 
 If you are using Windows Vista or older versions, you can use another editor [Sublime Text 2](http://www.sublimetext.com/2).
 
-Now you should have a working Ruby on Rails programming setup. Congrats!
-
 ### *3.* Update your browser
 
 If you use Internet Explorer, we recommend installing [Firefox](mozilla.org/firefox) or [Google Chrome](google.com/chrome).
@@ -239,6 +231,22 @@ node --version
 {% endhighlight %}
 
 Make sure it is displaying version number.
+
+### *5.* Check the environment
+
+Make sure that all works well by running the application generator command.
+
+{% highlight sh %}
+rails new myapp
+cd myapp
+rails server
+{% endhighlight %}
+
+Access to `http://localhost:3000` on browser, and you can see the 'Yay! You're on Rails!' page.
+
+Now you should have a working Ruby on Rails programming setup. Congrats!
+
+**Coach:** We recommend to check using a scaffold command and registing data in generated page by coaches, because we would get `ExecJS::RuntimeError` sometimes.
 
 <hr />
 

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -34,7 +34,7 @@ If your version number starts with 10.6, 10.7, 10.8, 10.9, 10.10 or 10.11 this g
 
 ### *3a.* If your OS X version is 10.9 or higher:
 
-If your version number starts with 10.9 or 10.10, follow these steps. We are installing homebrew and rbenv.
+If your version number starts with 10.9, 10.10 or 10.11, follow these steps. We are installing homebrew and rbenv.
 
 #### *3a1.* Install Command line tools on terminal:
 
@@ -134,7 +134,7 @@ Open `Command Prompt with Ruby on Rails` and run the following command:
 rails -v
 {% endhighlight %}
 
-If the Rails version is less than 4, update it using a following command:
+If the Rails version is less than 5, update it using a following command:
 
 {% highlight sh %}
 gem update rails --no-document

--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -229,8 +229,8 @@ Open [whatbrowser.org](http://whatbrowser.org) and update your browser if you do
 This is not strictly necessary, but it avoids a problem with and `ExecJS::RuntimeError` that might
 occur later  ([see stackoverflow](https://stackoverflow.com/questions/12520456/execjsruntimeerror-on-windows-trying-to-follow-rubytutorial)).
 
-* Go to [https://nodejs.org/](https://nodejs.org/) and install node
-* For windows users: reopen your Rails Command Shell
+* Go to [https://nodejs.org/](https://nodejs.org/) and install node LTS package
+* Reopen your Rails Command Shell
 
 Check your version of node
 
@@ -238,7 +238,7 @@ Check your version of node
 node --version
 {% endhighlight %}
 
-Make sure it is higher than `0.12`.
+Make sure it is displaying version number.
 
 <hr />
 


### PR DESCRIPTION
Update to Rails5 for mac and win.

I'm not native English speaker, so I'm waiting to review my sentences.

We've checked these new contents and we have no problem on win and mac in RailsGirls Tokyo (22th Jul.). 
But I'm happy to check this way on your environments. 😃 

We need a little complex way on Windows.

- Version up RailsInstaller to 3.2.0 to use Ruby 2.2.x.
  - Because we need Ruby2.2.2+ for Rails5.
  - But there is a bug in RailsInstaller3.2.0, so we have to run some commands to fix it.
- We got an error on coffee-script-source gem without node.js.
  - Move and create new sentence to check Rails environment after installing node.js.

And we should update other pages after this PR would be merged. 🌻 
