### PR TITLE
Updated link to Jekyll install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The guides use the [pygments](http://pygments.org/) library to do syntax highlig
 {% endhighlight %}
 ```
 
-If you aren't editing the code blocks, you can safely ignore this. If you want pygments, you can follow the [install instructions](https://github.com/mojombo/jekyll/wiki/Install) in the "Pygments" section.
+If you aren't editing the code blocks, you can safely ignore this. If you want pygments, you can follow the [install instructions](http://jekyllrb.com/docs/installation/) in the "Pygments" section.
 
 ### Run jekyll
 


### PR DESCRIPTION
New link: http://jekyllrb.com/docs/installation/